### PR TITLE
Feature/error

### DIFF
--- a/easy-glide-databinding/src/main/java/br/com/redcode/easyglide/databinding/library/EasyGlideBindingAdapters.kt
+++ b/easy-glide-databinding/src/main/java/br/com/redcode/easyglide/databinding/library/EasyGlideBindingAdapters.kt
@@ -5,16 +5,19 @@ import android.view.View
 import android.widget.ImageView
 import androidx.annotation.DrawableRes
 import androidx.databinding.BindingAdapter
-import br.com.redcode.easyglide.library.getBitmapThumbnail
-import br.com.redcode.easyglide.library.load
-import br.com.redcode.easyglide.library.loadInView
-import br.com.redcode.easyglide.library.loadWithCircleTransform
+import br.com.redcode.easyglide.library.*
 import com.bumptech.glide.Glide
 import com.bumptech.glide.load.engine.DiskCacheStrategy
 import com.bumptech.glide.load.resource.drawable.DrawableTransitionOptions
+import com.bumptech.glide.request.RequestOptions
+
+
 
 
 // -------------------------------------------------------------------------------------------------> ImageView
+
+private const val placeholder = android.R.drawable.stat_sys_download
+private val error = R.drawable.ic_error
 
 @BindingAdapter(value = ["app:loadCircle", "app:diskStrategy", "app:enableCrossfade", "app:roundingRadiusCorner"], requireAll = false)
 fun loadCircle(imageView: ImageView?, url: String?, diskStrategy: DiskCacheStrategy?, enableCrossfade: Boolean?, roundingRadiusCorner: Int?) {
@@ -28,17 +31,28 @@ fun loadCircle(imageView: ImageView?, url: String?, diskStrategy: DiskCacheStrat
 
 
 @BindingAdapter(
-    value = ["app:load", "app:enableCrossfade", "app:thumbnailWidth", "app:thumbnailHeight", "app:thumbnailSquare"],
+    value = ["app:load", "app:withPlaceholder", "app:withPlaceholderDrawable", "app:withError", "app:enableCrossfade", "app:thumbnailWidth", "app:thumbnailHeight", "app:thumbnailSquare"],
     requireAll = false
 )
 fun load(
     imageView: ImageView?,
     url: String?,
+    withPlaceholder: Boolean = false,
+    placeholderDrawable: Drawable?,
+    withError: Boolean = false,
     enableCrossfade: Boolean?,
     thumbnailWidth: Int?,
     thumbnailHeight: Int?,
     thumbnailSquare: Int?
 ) {
+    var requestOptions = if (withPlaceholder || placeholderDrawable != null) {
+        placeholderDrawable?.let {
+            RequestOptions().placeholder(it) } ?:
+            RequestOptions().placeholder(placeholder)
+    } else RequestOptions()
+    if (withError) {
+        requestOptions = requestOptions.error(error)
+    }
 
     if (url != null) {
         when {
@@ -53,6 +67,7 @@ fun load(
                             transition(DrawableTransitionOptions.withCrossFade())
                         }
                     }
+                    .apply(requestOptions)
                     .into(imageView)
             }
 
@@ -67,13 +82,15 @@ fun load(
                             transition(DrawableTransitionOptions.withCrossFade())
                         }
                     }
+                    .apply(requestOptions)
                     .into(imageView)
 
             }
 
             else -> {
-                imageView?.load(
+                imageView?.loadCompleteUrlImage(
                     url = url,
+                    glideRequestOption = requestOptions,
                     enableCrossfade = enableCrossfade
                 )
             }

--- a/easy-glide-databinding/src/main/java/br/com/redcode/easyglide/databinding/library/EasyGlideBindingAdapters.kt
+++ b/easy-glide-databinding/src/main/java/br/com/redcode/easyglide/databinding/library/EasyGlideBindingAdapters.kt
@@ -31,7 +31,7 @@ fun loadCircle(imageView: ImageView?, url: String?, diskStrategy: DiskCacheStrat
 
 
 @BindingAdapter(
-    value = ["app:load", "app:withPlaceholder", "app:withPlaceholderDrawable", "app:withError", "app:enableCrossfade", "app:thumbnailWidth", "app:thumbnailHeight", "app:thumbnailSquare"],
+    value = ["app:load", "app:withPlaceholder", "app:placeholderDrawable", "app:withError", "app:errorDrawable", "app:enableCrossfade", "app:thumbnailWidth", "app:thumbnailHeight", "app:thumbnailSquare"],
     requireAll = false
 )
 fun load(
@@ -40,6 +40,7 @@ fun load(
     withPlaceholder: Boolean = false,
     placeholderDrawable: Drawable?,
     withError: Boolean = false,
+    errorDrawable: Drawable?,
     enableCrossfade: Boolean?,
     thumbnailWidth: Int?,
     thumbnailHeight: Int?,
@@ -50,8 +51,9 @@ fun load(
             RequestOptions().placeholder(it) } ?:
             RequestOptions().placeholder(placeholder)
     } else RequestOptions()
-    if (withError) {
-        requestOptions = requestOptions.error(error)
+    if (withError || errorDrawable != null) {
+        requestOptions = errorDrawable?.let {
+            requestOptions.error(it) } ?: requestOptions.error(error)
     }
 
     if (url != null) {

--- a/easy-glide/src/main/java/br/com/redcode/easyglide/library/ExtensionImageView.kt
+++ b/easy-glide/src/main/java/br/com/redcode/easyglide/library/ExtensionImageView.kt
@@ -43,27 +43,60 @@ fun ImageView.load(url: String?,
 }
 
 fun ImageView.load(url: String?,
-                   withPlaceholder: Boolean,
+                   withPlaceholder: Boolean = false,
+                   withError: Boolean = false,
                    onSuccess: (() -> Unit)? = null,
                    enableCrossfade: Boolean? = null) {
-    val requestOption: RequestOptions = if (withPlaceholder) RequestOptions().error(error)
+    var requestOption: RequestOptions = if (withPlaceholder) RequestOptions()
         .placeholder(placeholder) else RequestOptions()
-    this.loadCompleteUrlImage(url = url, glideRequestOption = requestOption,
+    if (withError) {
+        requestOption = requestOption.error(error)
+    }
+    this.loadCompleteUrlImage(url = url,
+        glideRequestOption = requestOption,
+        onSuccess = onSuccess,
+        enableCrossfade = enableCrossfade)
+}
+
+fun ImageView.load(url: String?,
+                   withPlaceholder: Boolean = false,
+                   withError: Int,
+                   onSuccess: (() -> Unit)? = null,
+                   enableCrossfade: Boolean? = null) {
+    val requestOption: RequestOptions = if (withPlaceholder) RequestOptions().error(withError)
+        .placeholder(placeholder) else RequestOptions().error(withError)
+    this.loadCompleteUrlImage(url = url,
+        glideRequestOption = requestOption,
         onSuccess = onSuccess,
         enableCrossfade = enableCrossfade)
 }
 
 fun ImageView.load(url: String?,
                    withPlaceholder: Int,
+                   withError: Boolean = false,
                    onSuccess: (() -> Unit)? = null,
                    enableCrossfade: Boolean? = null) {
-    val requestOption: RequestOptions = RequestOptions().error(error)
-            .placeholder(withPlaceholder)
+    val requestOption: RequestOptions = if (withError) RequestOptions().error(error)
+        .placeholder(withPlaceholder) else RequestOptions().placeholder(withPlaceholder)
     this.loadCompleteUrlImage(url = url,
         glideRequestOption = requestOption,
         onSuccess = onSuccess,
         enableCrossfade = enableCrossfade)
 }
+
+fun ImageView.load(url: String?,
+                   withPlaceholder: Int,
+                   withError: Int,
+                   onSuccess: (() -> Unit)? = null,
+                   enableCrossfade: Boolean? = null) {
+    val requestOption: RequestOptions = RequestOptions().error(withError)
+        .placeholder(withPlaceholder)
+    this.loadCompleteUrlImage(url = url,
+        glideRequestOption = requestOption,
+        onSuccess = onSuccess,
+        enableCrossfade = enableCrossfade)
+}
+
 
 fun ImageView.loadCompleteUrlImage(
     url: String?,
@@ -116,39 +149,74 @@ fun ImageView.loadCompleteUrlImage(
 fun ImageView.load(bitmap: Bitmap?,
                    onSuccess: (() -> Unit)? = null,
                    enableCrossfade: Boolean? = null) {
-    this.loadCompleteBitmapImage(bitmap = bitmap, onSuccess = onSuccess,
+    this.loadCompleteBitmapImage(bitmap = bitmap,
+        glideRequestOption = RequestOptions(),
+        onSuccess = onSuccess,
+        enableCrossfade = enableCrossfade)
+}
+
+fun ImageView.load(bitmap: Bitmap?,
+                   withPlaceholder: Boolean = false,
+                   withError: Boolean = false,
+                   onSuccess: (() -> Unit)? = null,
+                   enableCrossfade: Boolean? = null) {
+    var requestOption: RequestOptions = if (withPlaceholder) RequestOptions()
+        .placeholder(placeholder) else RequestOptions()
+    if (withError) {
+        requestOption = requestOption.error(error)
+    }
+    this.loadCompleteBitmapImage(bitmap = bitmap,
+        glideRequestOption = requestOption,
+        onSuccess = onSuccess,
         enableCrossfade = enableCrossfade)
 }
 
 fun ImageView.load(bitmap: Bitmap?,
                    withPlaceholder: Boolean,
+                   withError: Int,
                    onSuccess: (() -> Unit)? = null,
                    enableCrossfade: Boolean? = null) {
-    this.loadCompleteBitmapImage(bitmap = bitmap, withPlaceholder = withPlaceholder,
+    val requestOption: RequestOptions = if (withPlaceholder) RequestOptions().error(withError)
+        .placeholder(placeholder) else RequestOptions().error(withError)
+    this.loadCompleteBitmapImage(bitmap = bitmap,
+        glideRequestOption = requestOption,
         onSuccess = onSuccess,
         enableCrossfade = enableCrossfade)
 }
 
 fun ImageView.load(bitmap: Bitmap?,
                    withPlaceholder: Int,
+                   withError: Boolean = false,
                    onSuccess: (() -> Unit)? = null,
                    enableCrossfade: Boolean? = null) {
-    this.loadCompleteBitmapImage(bitmap = bitmap, placeholderResId = withPlaceholder,
+    val requestOption: RequestOptions = if (withError) RequestOptions().error(error)
+        .placeholder(withPlaceholder) else RequestOptions().placeholder(withPlaceholder)
+    this.loadCompleteBitmapImage(bitmap = bitmap,
+        glideRequestOption = requestOption,
         onSuccess = onSuccess,
         enableCrossfade = enableCrossfade)
 }
 
+fun ImageView.load(bitmap: Bitmap?,
+                   withPlaceholder: Int,
+                   withError: Int,
+                   onSuccess: (() -> Unit)? = null,
+                   enableCrossfade: Boolean? = null) {
+    val requestOption: RequestOptions = RequestOptions().error(withError)
+        .placeholder(withPlaceholder)
+    this.loadCompleteBitmapImage(bitmap = bitmap,
+        glideRequestOption = requestOption,
+        onSuccess = onSuccess,
+        enableCrossfade = enableCrossfade)
+}
+
+
 private fun ImageView.loadCompleteBitmapImage(
         bitmap: Bitmap?,
-        placeholderResId: Int? = null,
-        withPlaceholder: Boolean = false,
+        glideRequestOption: RequestOptions,
         onSuccess: (() -> Unit)? = null,
         enableCrossfade: Boolean? = null
 ) {
-    val requestOption: RequestOptions = if (withPlaceholder || placeholderResId != null) {
-        RequestOptions().error(error)
-                .placeholder(placeholderResId?.let { it } ?: placeholder)
-    } else RequestOptions()
     if (bitmap != null) {
         val callback = object : RequestListener<Drawable> {
             override fun onLoadFailed(
@@ -174,7 +242,7 @@ private fun ImageView.loadCompleteBitmapImage(
 
         Glide.with(context)
             .load(bitmap)
-            .apply(requestOption)
+            .apply(glideRequestOption)
             .apply {
                 if (enableCrossfade == null || enableCrossfade) {
                     transition(DrawableTransitionOptions.withCrossFade())

--- a/easy-glide/src/main/java/br/com/redcode/easyglide/library/ExtensionImageView.kt
+++ b/easy-glide/src/main/java/br/com/redcode/easyglide/library/ExtensionImageView.kt
@@ -33,16 +33,29 @@ private const val placeholder = android.R.drawable.stat_sys_download
 private val error = R.drawable.ic_error
 
 // URL
-fun ImageView.load(url: String?) {
-    this.loadCompleteUrlImage(url = url)
+fun ImageView.load(url: String?,
+                   onSuccess: (() -> Unit)? = null,
+                   enableCrossfade: Boolean? = null) {
+    this.loadCompleteUrlImage(url = url, onSuccess = onSuccess,
+        enableCrossfade = enableCrossfade)
 }
 
-fun ImageView.load(url: String?, withPlaceholder: Boolean) {
-    this.loadCompleteUrlImage(url = url, withPlaceholder = withPlaceholder)
+fun ImageView.load(url: String?,
+                   withPlaceholder: Boolean,
+                   onSuccess: (() -> Unit)? = null,
+                   enableCrossfade: Boolean? = null) {
+    this.loadCompleteUrlImage(url = url, withPlaceholder = withPlaceholder,
+        onSuccess = onSuccess,
+        enableCrossfade = enableCrossfade)
 }
 
-fun ImageView.load(url: String?, withPlaceholder: Int) {
-    this.loadCompleteUrlImage(url = url, placeholderResId = withPlaceholder)
+fun ImageView.load(url: String?,
+                   withPlaceholder: Int,
+                   onSuccess: (() -> Unit)? = null,
+                   enableCrossfade: Boolean? = null) {
+    this.loadCompleteUrlImage(url = url, placeholderResId = withPlaceholder,
+        onSuccess = onSuccess,
+        enableCrossfade = enableCrossfade)
 }
 
 private fun ImageView.loadCompleteUrlImage(
@@ -107,16 +120,29 @@ private fun ImageView.loadCompleteUrlImage(
 }
 
 // Bitmap
-fun ImageView.load(bitmap: Bitmap?) {
-    this.loadCompleteBitmapImage(bitmap = bitmap)
+fun ImageView.load(bitmap: Bitmap?,
+                   onSuccess: (() -> Unit)? = null,
+                   enableCrossfade: Boolean? = null) {
+    this.loadCompleteBitmapImage(bitmap = bitmap, onSuccess = onSuccess,
+        enableCrossfade = enableCrossfade)
 }
 
-fun ImageView.load(bitmap: Bitmap?, withPlaceholder: Boolean) {
-    this.loadCompleteBitmapImage(bitmap = bitmap, withPlaceholder = withPlaceholder)
+fun ImageView.load(bitmap: Bitmap?,
+                   withPlaceholder: Boolean,
+                   onSuccess: (() -> Unit)? = null,
+                   enableCrossfade: Boolean? = null) {
+    this.loadCompleteBitmapImage(bitmap = bitmap, withPlaceholder = withPlaceholder,
+        onSuccess = onSuccess,
+        enableCrossfade = enableCrossfade)
 }
 
-fun ImageView.load(bitmap: Bitmap?, withPlaceholder: Int) {
-    this.loadCompleteBitmapImage(bitmap = bitmap, placeholderResId = withPlaceholder)
+fun ImageView.load(bitmap: Bitmap?,
+                   withPlaceholder: Int,
+                   onSuccess: (() -> Unit)? = null,
+                   enableCrossfade: Boolean? = null) {
+    this.loadCompleteBitmapImage(bitmap = bitmap, placeholderResId = withPlaceholder,
+        onSuccess = onSuccess,
+        enableCrossfade = enableCrossfade)
 }
 
 private fun ImageView.loadCompleteBitmapImage(

--- a/easy-glide/src/main/java/br/com/redcode/easyglide/library/ExtensionImageView.kt
+++ b/easy-glide/src/main/java/br/com/redcode/easyglide/library/ExtensionImageView.kt
@@ -37,7 +37,8 @@ fun ImageView.load(url: String?,
                    onSuccess: (() -> Unit)? = null,
                    enableCrossfade: Boolean? = null) {
     this.loadCompleteUrlImage(url = url,
-        glideRequestOption = RequestOptions(),
+        glideRequestOption = buildRequestOptions(
+            false, placeholder, false, error),
         onSuccess = onSuccess,
         enableCrossfade = enableCrossfade)
 }
@@ -47,13 +48,9 @@ fun ImageView.load(url: String?,
                    withError: Boolean = false,
                    onSuccess: (() -> Unit)? = null,
                    enableCrossfade: Boolean? = null) {
-    var requestOption: RequestOptions = if (withPlaceholder) RequestOptions()
-        .placeholder(placeholder) else RequestOptions()
-    if (withError) {
-        requestOption = requestOption.error(error)
-    }
     this.loadCompleteUrlImage(url = url,
-        glideRequestOption = requestOption,
+        glideRequestOption = buildRequestOptions(
+            withPlaceholder, placeholder, withError, error),
         onSuccess = onSuccess,
         enableCrossfade = enableCrossfade)
 }
@@ -63,10 +60,9 @@ fun ImageView.load(url: String?,
                    withError: Int,
                    onSuccess: (() -> Unit)? = null,
                    enableCrossfade: Boolean? = null) {
-    val requestOption: RequestOptions = if (withPlaceholder) RequestOptions().error(withError)
-        .placeholder(placeholder) else RequestOptions().error(withError)
     this.loadCompleteUrlImage(url = url,
-        glideRequestOption = requestOption,
+        glideRequestOption = buildRequestOptions(
+            withPlaceholder, placeholder, true, withError),
         onSuccess = onSuccess,
         enableCrossfade = enableCrossfade)
 }
@@ -76,10 +72,9 @@ fun ImageView.load(url: String?,
                    withError: Boolean = false,
                    onSuccess: (() -> Unit)? = null,
                    enableCrossfade: Boolean? = null) {
-    val requestOption: RequestOptions = if (withError) RequestOptions().error(error)
-        .placeholder(withPlaceholder) else RequestOptions().placeholder(withPlaceholder)
     this.loadCompleteUrlImage(url = url,
-        glideRequestOption = requestOption,
+        glideRequestOption = buildRequestOptions(
+            true, withPlaceholder, withError, error),
         onSuccess = onSuccess,
         enableCrossfade = enableCrossfade)
 }
@@ -89,14 +84,12 @@ fun ImageView.load(url: String?,
                    withError: Int,
                    onSuccess: (() -> Unit)? = null,
                    enableCrossfade: Boolean? = null) {
-    val requestOption: RequestOptions = RequestOptions().error(withError)
-        .placeholder(withPlaceholder)
     this.loadCompleteUrlImage(url = url,
-        glideRequestOption = requestOption,
+        glideRequestOption = buildRequestOptions(
+            true, withPlaceholder, true, withError),
         onSuccess = onSuccess,
         enableCrossfade = enableCrossfade)
 }
-
 
 fun ImageView.loadCompleteUrlImage(
     url: String?,
@@ -150,7 +143,8 @@ fun ImageView.load(bitmap: Bitmap?,
                    onSuccess: (() -> Unit)? = null,
                    enableCrossfade: Boolean? = null) {
     this.loadCompleteBitmapImage(bitmap = bitmap,
-        glideRequestOption = RequestOptions(),
+        glideRequestOption = buildRequestOptions(
+            false, placeholder, false, error),
         onSuccess = onSuccess,
         enableCrossfade = enableCrossfade)
 }
@@ -160,13 +154,9 @@ fun ImageView.load(bitmap: Bitmap?,
                    withError: Boolean = false,
                    onSuccess: (() -> Unit)? = null,
                    enableCrossfade: Boolean? = null) {
-    var requestOption: RequestOptions = if (withPlaceholder) RequestOptions()
-        .placeholder(placeholder) else RequestOptions()
-    if (withError) {
-        requestOption = requestOption.error(error)
-    }
     this.loadCompleteBitmapImage(bitmap = bitmap,
-        glideRequestOption = requestOption,
+        glideRequestOption = buildRequestOptions(
+            withPlaceholder, placeholder, withError, error),
         onSuccess = onSuccess,
         enableCrossfade = enableCrossfade)
 }
@@ -176,10 +166,9 @@ fun ImageView.load(bitmap: Bitmap?,
                    withError: Int,
                    onSuccess: (() -> Unit)? = null,
                    enableCrossfade: Boolean? = null) {
-    val requestOption: RequestOptions = if (withPlaceholder) RequestOptions().error(withError)
-        .placeholder(placeholder) else RequestOptions().error(withError)
     this.loadCompleteBitmapImage(bitmap = bitmap,
-        glideRequestOption = requestOption,
+        glideRequestOption = buildRequestOptions(
+            withPlaceholder, placeholder, true, withError),
         onSuccess = onSuccess,
         enableCrossfade = enableCrossfade)
 }
@@ -189,10 +178,9 @@ fun ImageView.load(bitmap: Bitmap?,
                    withError: Boolean = false,
                    onSuccess: (() -> Unit)? = null,
                    enableCrossfade: Boolean? = null) {
-    val requestOption: RequestOptions = if (withError) RequestOptions().error(error)
-        .placeholder(withPlaceholder) else RequestOptions().placeholder(withPlaceholder)
     this.loadCompleteBitmapImage(bitmap = bitmap,
-        glideRequestOption = requestOption,
+        glideRequestOption = buildRequestOptions(
+            true, withPlaceholder, withError, error),
         onSuccess = onSuccess,
         enableCrossfade = enableCrossfade)
 }
@@ -202,10 +190,9 @@ fun ImageView.load(bitmap: Bitmap?,
                    withError: Int,
                    onSuccess: (() -> Unit)? = null,
                    enableCrossfade: Boolean? = null) {
-    val requestOption: RequestOptions = RequestOptions().error(withError)
-        .placeholder(withPlaceholder)
     this.loadCompleteBitmapImage(bitmap = bitmap,
-        glideRequestOption = requestOption,
+        glideRequestOption = buildRequestOptions(
+            true, withPlaceholder, true, withError),
         onSuccess = onSuccess,
         enableCrossfade = enableCrossfade)
 }
@@ -386,4 +373,13 @@ fun getBitmapThumbnail(pathFile: String, thumbSquare: Int? = null, width: Int? =
     val mHeight = height ?: mSquare
 
     return ThumbnailUtils.extractThumbnail(BitmapFactory.decodeFile(pathFile), mWidth, mHeight)
+}
+
+private fun buildRequestOptions(withPlaceholder: Boolean,
+                                placeholderResId: Int,
+                                withError: Boolean,
+                                errorResId: Int): RequestOptions {
+    val requestOptions: RequestOptions = if (withPlaceholder)
+        RequestOptions().placeholder(placeholderResId) else RequestOptions()
+    return if (withError) requestOptions.error(errorResId) else requestOptions
 }

--- a/easy-glide/src/main/java/br/com/redcode/easyglide/library/ExtensionImageView.kt
+++ b/easy-glide/src/main/java/br/com/redcode/easyglide/library/ExtensionImageView.kt
@@ -33,39 +33,140 @@ private const val placeholder = android.R.drawable.stat_sys_download
 private val error = R.drawable.ic_error
 
 // URL
-fun ImageView.load(
-    url: String?,
-    onSuccess: (() -> Unit)? = null,
-    requestOption: RequestOptions = RequestOptions().error(error).placeholder(placeholder),
-    enableCrossfade: Boolean? = null
+fun ImageView.load(url: String?) {
+    this.loadCompleteUrlImage(url = url)
+}
+
+fun ImageView.load(url: String?, withPlaceholder: Boolean) {
+    this.loadCompleteUrlImage(url = url, withPlaceholder = withPlaceholder)
+}
+
+fun ImageView.load(url: String?, withPlaceholder: Int) {
+    this.loadCompleteUrlImage(url = url, placeholderResId = withPlaceholder)
+}
+
+private fun ImageView.loadCompleteUrlImage(
+        url: String?,
+        placeholderResId: Int? = null,
+        withPlaceholder: Boolean = false,
+        onSuccess: (() -> Unit)? = null,
+        enableCrossfade: Boolean? = null
 ) {
+    val requestOption: RequestOptions? = if (withPlaceholder || placeholderResId != null) {
+        RequestOptions().error(error)
+                .placeholder(placeholderResId?.let { it } ?: placeholder)
+    } else null
     url?.let {
         if (it.isNotBlank()) {
             val callback = object : RequestListener<Drawable> {
                 override fun onLoadFailed(
-                    e: GlideException?,
-                    model: Any?,
-                    target: Target<Drawable>?,
-                    isFirstResource: Boolean
+                        e: GlideException?,
+                        model: Any?,
+                        target: Target<Drawable>?,
+                        isFirstResource: Boolean
                 ): Boolean {
                     return true
                 }
 
                 override fun onResourceReady(
-                    resource: Drawable?,
-                    model: Any?,
-                    target: Target<Drawable>?,
-                    dataSource: DataSource?,
-                    isFirstResource: Boolean
+                        resource: Drawable?,
+                        model: Any?,
+                        target: Target<Drawable>?,
+                        dataSource: DataSource?,
+                        isFirstResource: Boolean
                 ): Boolean {
                     onSuccess?.invoke()
                     return false
                 }
             }
 
+            requestOption?.let {
+                Glide.with(context)
+                        .load(url)
+                        .apply(it)
+                        .apply {
+                            if (enableCrossfade == null || enableCrossfade) {
+                                transition(DrawableTransitionOptions.withCrossFade())
+                            }
+                        }
+                        .thumbnail(0.25f)
+                        .listener(callback)
+                        .into(this)
+            } ?: Glide.with(context)
+                    .load(url)
+                    .apply {
+                        if (enableCrossfade == null || enableCrossfade) {
+                            transition(DrawableTransitionOptions.withCrossFade())
+                        }
+                    }
+                    .thumbnail(0.25f)
+                    .listener(callback)
+                    .into(this)
+        }
+    }
+}
+
+// Bitmap
+fun ImageView.load(bitmap: Bitmap?) {
+    this.loadCompleteBitmapImage(bitmap = bitmap)
+}
+
+fun ImageView.load(bitmap: Bitmap?, withPlaceholder: Boolean) {
+    this.loadCompleteBitmapImage(bitmap = bitmap, withPlaceholder = withPlaceholder)
+}
+
+fun ImageView.load(bitmap: Bitmap?, withPlaceholder: Int) {
+    this.loadCompleteBitmapImage(bitmap = bitmap, placeholderResId = withPlaceholder)
+}
+
+private fun ImageView.loadCompleteBitmapImage(
+        bitmap: Bitmap?,
+        placeholderResId: Int? = null,
+        withPlaceholder: Boolean = false,
+        onSuccess: (() -> Unit)? = null,
+        enableCrossfade: Boolean? = null
+) {
+    val requestOption: RequestOptions? = if (withPlaceholder || placeholderResId != null) {
+        RequestOptions().error(error)
+                .placeholder(placeholderResId?.let { it } ?: placeholder)
+    } else null
+    if (bitmap != null) {
+        val callback = object : RequestListener<Drawable> {
+            override fun onLoadFailed(
+                    e: GlideException?,
+                    model: Any?,
+                    target: Target<Drawable>?,
+                    isFirstResource: Boolean
+            ): Boolean {
+                return true
+            }
+
+            override fun onResourceReady(
+                    resource: Drawable?,
+                    model: Any?,
+                    target: Target<Drawable>?,
+                    dataSource: DataSource?,
+                    isFirstResource: Boolean
+            ): Boolean {
+                onSuccess?.invoke()
+                return false
+            }
+        }
+
+        requestOption?.let {
             Glide.with(context)
-                .load(url)
-                .apply(requestOption)
+                    .load(bitmap)
+                    .apply(it)
+                    .apply {
+                        if (enableCrossfade == null || enableCrossfade) {
+                            transition(DrawableTransitionOptions.withCrossFade())
+                        }
+                    }
+                    .thumbnail(0.25f)
+                    .listener(callback)
+                    .into(this)
+        } ?: Glide.with(context)
+                .load(bitmap)
                 .apply {
                     if (enableCrossfade == null || enableCrossfade) {
                         transition(DrawableTransitionOptions.withCrossFade())
@@ -74,55 +175,8 @@ fun ImageView.load(
                 .thumbnail(0.25f)
                 .listener(callback)
                 .into(this)
-        }
     }
 }
-
-// Bitmap
-fun ImageView.load(
-    bitmap: Bitmap?,
-    onSuccess: (() -> Unit)? = null,
-    requestOption: RequestOptions = RequestOptions().error(error).placeholder(placeholder),
-    enableCrossfade: Boolean? = null
-) {
-    if (bitmap != null) {
-        val callback = object : RequestListener<Drawable> {
-            override fun onLoadFailed(
-                e: GlideException?,
-                model: Any?,
-                target: Target<Drawable>?,
-                isFirstResource: Boolean
-            ): Boolean {
-                return true
-            }
-
-            override fun onResourceReady(
-                resource: Drawable?,
-                model: Any?,
-                target: Target<Drawable>?,
-                dataSource: DataSource?,
-                isFirstResource: Boolean
-            ): Boolean {
-                onSuccess?.invoke()
-                return false
-            }
-        }
-
-        Glide.with(context)
-            .load(bitmap)
-            .apply(requestOption)
-            .apply {
-                if (enableCrossfade == null || enableCrossfade) {
-                    transition(DrawableTransitionOptions.withCrossFade())
-                }
-            }
-            .thumbnail(0.25f)
-            .listener(callback)
-            .into(this)
-    }
-}
-
-
 fun ImageView.load(drawable: Int?, requestOption: RequestOptions? = RequestOptions()) {
     drawable.let {
         Glide.with(context)
@@ -141,6 +195,7 @@ fun View.loadInView(drawable: Int, requestOption: RequestOptions? = RequestOptio
             background = resource
         }
     })
+
 
 fun View.loadInView(drawable: Drawable, requestOption: RequestOptions? = RequestOptions()) = Glide.with(this)
     .load(drawable)

--- a/easy-glide/src/main/java/br/com/redcode/easyglide/library/ExtensionImageView.kt
+++ b/easy-glide/src/main/java/br/com/redcode/easyglide/library/ExtensionImageView.kt
@@ -36,7 +36,9 @@ private val error = R.drawable.ic_error
 fun ImageView.load(url: String?,
                    onSuccess: (() -> Unit)? = null,
                    enableCrossfade: Boolean? = null) {
-    this.loadCompleteUrlImage(url = url, onSuccess = onSuccess,
+    this.loadCompleteUrlImage(url = url,
+        glideRequestOption = RequestOptions(),
+        onSuccess = onSuccess,
         enableCrossfade = enableCrossfade)
 }
 
@@ -44,7 +46,9 @@ fun ImageView.load(url: String?,
                    withPlaceholder: Boolean,
                    onSuccess: (() -> Unit)? = null,
                    enableCrossfade: Boolean? = null) {
-    this.loadCompleteUrlImage(url = url, withPlaceholder = withPlaceholder,
+    val requestOption: RequestOptions = if (withPlaceholder) RequestOptions().error(error)
+        .placeholder(placeholder) else RequestOptions()
+    this.loadCompleteUrlImage(url = url, glideRequestOption = requestOption,
         onSuccess = onSuccess,
         enableCrossfade = enableCrossfade)
 }
@@ -53,22 +57,20 @@ fun ImageView.load(url: String?,
                    withPlaceholder: Int,
                    onSuccess: (() -> Unit)? = null,
                    enableCrossfade: Boolean? = null) {
-    this.loadCompleteUrlImage(url = url, placeholderResId = withPlaceholder,
+    val requestOption: RequestOptions = RequestOptions().error(error)
+            .placeholder(withPlaceholder)
+    this.loadCompleteUrlImage(url = url,
+        glideRequestOption = requestOption,
         onSuccess = onSuccess,
         enableCrossfade = enableCrossfade)
 }
 
-private fun ImageView.loadCompleteUrlImage(
-        url: String?,
-        placeholderResId: Int? = null,
-        withPlaceholder: Boolean = false,
-        onSuccess: (() -> Unit)? = null,
-        enableCrossfade: Boolean? = null
+fun ImageView.loadCompleteUrlImage(
+    url: String?,
+    glideRequestOption: RequestOptions,
+    onSuccess: (() -> Unit)? = null,
+    enableCrossfade: Boolean? = null
 ) {
-    val requestOption: RequestOptions? = if (withPlaceholder || placeholderResId != null) {
-        RequestOptions().error(error)
-                .placeholder(placeholderResId?.let { it } ?: placeholder)
-    } else null
     url?.let {
         if (it.isNotBlank()) {
             val callback = object : RequestListener<Drawable> {
@@ -93,10 +95,10 @@ private fun ImageView.loadCompleteUrlImage(
                 }
             }
 
-            requestOption?.let {
-                Glide.with(context)
+
+            Glide.with(context)
                         .load(url)
-                        .apply(it)
+                        .apply(glideRequestOption)
                         .apply {
                             if (enableCrossfade == null || enableCrossfade) {
                                 transition(DrawableTransitionOptions.withCrossFade())
@@ -105,19 +107,10 @@ private fun ImageView.loadCompleteUrlImage(
                         .thumbnail(0.25f)
                         .listener(callback)
                         .into(this)
-            } ?: Glide.with(context)
-                    .load(url)
-                    .apply {
-                        if (enableCrossfade == null || enableCrossfade) {
-                            transition(DrawableTransitionOptions.withCrossFade())
-                        }
-                    }
-                    .thumbnail(0.25f)
-                    .listener(callback)
-                    .into(this)
-        }
+
     }
-}
+}}
+
 
 // Bitmap
 fun ImageView.load(bitmap: Bitmap?,
@@ -152,10 +145,10 @@ private fun ImageView.loadCompleteBitmapImage(
         onSuccess: (() -> Unit)? = null,
         enableCrossfade: Boolean? = null
 ) {
-    val requestOption: RequestOptions? = if (withPlaceholder || placeholderResId != null) {
+    val requestOption: RequestOptions = if (withPlaceholder || placeholderResId != null) {
         RequestOptions().error(error)
                 .placeholder(placeholderResId?.let { it } ?: placeholder)
-    } else null
+    } else RequestOptions()
     if (bitmap != null) {
         val callback = object : RequestListener<Drawable> {
             override fun onLoadFailed(
@@ -179,28 +172,17 @@ private fun ImageView.loadCompleteBitmapImage(
             }
         }
 
-        requestOption?.let {
-            Glide.with(context)
-                    .load(bitmap)
-                    .apply(it)
-                    .apply {
-                        if (enableCrossfade == null || enableCrossfade) {
-                            transition(DrawableTransitionOptions.withCrossFade())
-                        }
-                    }
-                    .thumbnail(0.25f)
-                    .listener(callback)
-                    .into(this)
-        } ?: Glide.with(context)
-                .load(bitmap)
-                .apply {
-                    if (enableCrossfade == null || enableCrossfade) {
-                        transition(DrawableTransitionOptions.withCrossFade())
-                    }
+        Glide.with(context)
+            .load(bitmap)
+            .apply(requestOption)
+            .apply {
+                if (enableCrossfade == null || enableCrossfade) {
+                    transition(DrawableTransitionOptions.withCrossFade())
                 }
-                .thumbnail(0.25f)
-                .listener(callback)
-                .into(this)
+            }
+            .thumbnail(0.25f)
+            .listener(callback)
+            .into(this)
     }
 }
 fun ImageView.load(drawable: Int?, requestOption: RequestOptions? = RequestOptions()) {


### PR DESCRIPTION
Add support for no error, default error, and custom error in the extension. 

Note for both bitmap and url there a function available for the user to simply bit a custom 
`RequestOptions()` object if they want specific options not otherwise available. The other `imageView.load( ... )` functions simplify the input for quick and easy access to the underlying glide implementation. 