### PR TITLE
#10 Add consumer proguard in library

### DIFF
--- a/easy-glide/build.gradle
+++ b/easy-glide/build.gradle
@@ -13,6 +13,7 @@ android {
         targetSdkVersion 29
         versionCode 1
         versionName "1.0"
+        consumerProguardFiles 'consumer-proguard-rules.pro'
     }
 
     buildTypes {

--- a/easy-glide/consumer-proguard-rules.pro
+++ b/easy-glide/consumer-proguard-rules.pro
@@ -1,0 +1,11 @@
+-keep public class * implements com.bumptech.glide.module.GlideModule
+-keep class * extends com.bumptech.glide.module.AppGlideModule {
+ <init>(...);
+}
+-keep public enum com.bumptech.glide.load.ImageHeaderParser$** {
+  **[] $VALUES;
+  public *;
+}
+
+# Uncomment for DexGuard only
+#-keepresourcexmlelements manifest/application/meta-data@value=GlideModule


### PR DESCRIPTION
Added `Glide` proguard rules to `consumer-proguard-rules.pro` file and configure them in the `build.gradle` to be used as consumer rules.